### PR TITLE
Add automatic RAG instructions loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ Key flags: `--model/-m`, `--approval-mode/-a`, and `--quiet/-q`.
 Codex merges Markdown instructions in this order:
 
 1. `~/.codex/instructions.md` – personal global guidance
-2. `codex.md` at repo root – shared project notes
-3. `codex.md` in cwd – sub‑package specifics
+2. `~/.codex/rag/RAG.md` – automatically loaded RAG context
+3. `codex.md` at repo root – shared project notes
+4. `codex.md` in cwd – sub‑package specifics
 
 Disable with `--no-project-doc` or `CODEX_DISABLE_PROJECT_DOC=1`.
 
@@ -296,6 +297,10 @@ You can also define custom instructions:
 - Always respond with emojis
 - Only use git commands if I explicitly mention you should
 ```
+
+Additionally, any Markdown placed at `~/.codex/rag/RAG.md` will be loaded
+automatically for every session. Put your RAG context here and Codex will merge
+it with the other instructions.
 
 ### Alternative AI Providers
 

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -29,6 +29,8 @@ export const CONFIG_YML_FILEPATH = join(CONFIG_DIR, "config.yml");
 // work unchanged.
 export const CONFIG_FILEPATH = CONFIG_JSON_FILEPATH;
 export const INSTRUCTIONS_FILEPATH = join(CONFIG_DIR, "instructions.md");
+// If present, this file is automatically appended to the user's instructions.
+export const RAG_FILEPATH = join(CONFIG_DIR, "rag", "RAG.md");
 
 export const OPENAI_TIMEOUT_MS =
   parseInt(process.env["OPENAI_TIMEOUT_MS"] || "0", 10) || undefined;
@@ -288,6 +290,11 @@ export const loadInstructions = (
     ? readFileSync(instructionsFilePathResolved, "utf-8")
     : DEFAULT_INSTRUCTIONS;
 
+  // Additional RAG instructions are loaded from RAG_FILEPATH if present.
+  const ragInstructions = existsSync(RAG_FILEPATH)
+    ? readFileSync(RAG_FILEPATH, "utf-8")
+    : "";
+
   // Project doc support.
   const shouldLoadProjectDoc =
     !options.disableProjectDoc &&
@@ -314,7 +321,11 @@ export const loadInstructions = (
     }
   }
 
-  const combinedInstructions = [userInstructions, projectDoc]
+  const baseInstructions = [userInstructions, ragInstructions]
+    .filter((s) => s && s.trim() !== "")
+    .join("\n\n");
+
+  const combinedInstructions = [baseInstructions, projectDoc]
     .filter((s) => s && s.trim() !== "")
     .join("\n\n--- project-doc ---\n\n");
 


### PR DESCRIPTION
## Summary
- append `RAG.md` to instructions if placed at `~/.codex/rag/RAG.md`
- document the new behaviour in README

## Testing
- `npm test` *(fails: vitest not found)*