### PR TITLE
Add repository-level RAG.md loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ Key flags: `--model/-m`, `--approval-mode/-a`, and `--quiet/-q`.
 
 Codex merges Markdown instructions in this order:
 
-1. `~/.codex/instructions.md` – personal global guidance
-2. `~/.codex/rag/RAG.md` – automatically loaded RAG context
+1. `RAG.md` at the repository root (or `~/.codex/rag/RAG.md`) – automatically loaded RAG context
+2. `~/.codex/instructions.md` – personal global guidance
 3. `codex.md` at repo root – shared project notes
 4. `codex.md` in cwd – sub‑package specifics
 
@@ -298,9 +298,10 @@ You can also define custom instructions:
 - Only use git commands if I explicitly mention you should
 ```
 
-Additionally, any Markdown placed at `~/.codex/rag/RAG.md` will be loaded
-automatically for every session. Put your RAG context here and Codex will merge
-it with the other instructions.
+Additionally, any Markdown placed at `RAG.md` in the repository root will be
+loaded automatically for every session. The legacy location
+`~/.codex/rag/RAG.md` is also supported. Put your RAG context in one of these
+locations and Codex will merge it with the other instructions.
 
 ### Alternative AI Providers
 

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -31,6 +31,9 @@ export const CONFIG_FILEPATH = CONFIG_JSON_FILEPATH;
 export const INSTRUCTIONS_FILEPATH = join(CONFIG_DIR, "instructions.md");
 // If present, this file is automatically appended to the user's instructions.
 export const RAG_FILEPATH = join(CONFIG_DIR, "rag", "RAG.md");
+// Name of the repository-level RAG file. If present at the Git root it will be
+// loaded automatically for every session.
+export const REPO_RAG_FILENAME = "RAG.md";
 
 export const OPENAI_TIMEOUT_MS =
   parseInt(process.env["OPENAI_TIMEOUT_MS"] || "0", 10) || undefined;
@@ -136,6 +139,41 @@ function defaultModelsForProvider(provider: string): {
         agentic: "",
         fullContext: "",
       };
+  }
+}
+
+function findGitRoot(startDir: string): string | null {
+  let dir = resolvePath(startDir);
+  while (true) {
+    if (existsSync(join(dir, ".git"))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+function loadRepoRag(cwd: string): { content: string; path: string | null } {
+  const gitRoot = findGitRoot(cwd);
+  if (!gitRoot) {
+    console.warn(`[codex] No Git repository found when looking for ${REPO_RAG_FILENAME}`);
+    return { content: "", path: null };
+  }
+  const ragPath = join(gitRoot, REPO_RAG_FILENAME);
+  if (!existsSync(ragPath)) {
+    console.warn(`[codex] ${REPO_RAG_FILENAME} not found at repository root (${ragPath})`);
+    return { content: "", path: null };
+  }
+  try {
+    const content = readFileSync(ragPath, "utf-8");
+    console.log(`[codex] Loaded ${REPO_RAG_FILENAME} from ${ragPath} (${content.length} bytes)`);
+    return { content, path: ragPath };
+  } catch {
+    console.warn(`[codex] Failed to read ${REPO_RAG_FILENAME} at ${ragPath}`);
+    return { content: "", path: null };
   }
 }
 
@@ -290,10 +328,17 @@ export const loadInstructions = (
     ? readFileSync(instructionsFilePathResolved, "utf-8")
     : DEFAULT_INSTRUCTIONS;
 
-  // Additional RAG instructions are loaded from RAG_FILEPATH if present.
-  const ragInstructions = existsSync(RAG_FILEPATH)
+  const cwd = options.cwd ?? process.cwd();
+
+  // Additional RAG instructions are loaded from the repository root and from
+  // RAG_FILEPATH if present.
+  const repoRag = loadRepoRag(cwd).content;
+  const ragHome = existsSync(RAG_FILEPATH)
     ? readFileSync(RAG_FILEPATH, "utf-8")
     : "";
+  const ragInstructions = [repoRag, ragHome]
+    .filter((s) => s && s.trim() !== "")
+    .join("\n\n");
 
   // Project doc support.
   const shouldLoadProjectDoc =
@@ -321,7 +366,7 @@ export const loadInstructions = (
     }
   }
 
-  const baseInstructions = [userInstructions, ragInstructions]
+  const baseInstructions = [ragInstructions, userInstructions]
     .filter((s) => s && s.trim() !== "")
     .join("\n\n");
 


### PR DESCRIPTION
## Summary
- load `RAG.md` from the git root if present
- log success or failure when loading repository RAG docs
- document new behaviour in the README so RAG instructions can be placed in the repository root or in `~/.codex/rag/RAG.md`
- ensure repository RAG instructions are merged before personal instructions

## Testing
- `npm test` *(fails: Missing script)*
- `cd codex-cli && npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run typecheck` *(fails: Cannot find type definitions)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.