### PR TITLE
Fix instruction order in docs and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ Key flags: `--model/-m`, `--approval-mode/-a`, and `--quiet/-q`.
 
 Codex merges Markdown instructions in this order:
 
-1. `~/.codex/instructions.md` – personal global guidance
-2. `RAG.md` at the repository root (or `~/.codex/rag/RAG.md`) – automatically loaded RAG context
+1. `RAG.md` at the repository root (or `~/.codex/rag/RAG.md`) – automatically loaded RAG context
+2. `~/.codex/instructions.md` – personal global guidance
 3. `codex.md` at repo root – shared project notes
 4. `codex.md` in cwd – sub‑package specifics
 

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -366,7 +366,7 @@ export const loadInstructions = (
     }
   }
 
-  const baseInstructions = [userInstructions, ragInstructions]
+  const baseInstructions = [ragInstructions, userInstructions]
     .filter((s) => s && s.trim() !== "")
     .join("\n\n");
 


### PR DESCRIPTION
## Notes
- reorder baseInstructions to put RAG instructions first
- update README to document new merge order

## Testing
- `npm run format`
- `npm test` *(fails: sh: 1: vitest: not found)*